### PR TITLE
Fixes for having multiple starter kit apps installed

### DIFF
--- a/content/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/components/ionic-menu-list/.content.xml
+++ b/content/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/components/ionic-menu-list/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:Component"
     jcr:title="Ionic Menu List"
     sling:resourceSuperType="geometrixx-outdoors-app/components/menu-list"
-    componentGroup="PhoneGap"/>
+    componentGroup="brand_name_placeholder app_name_placeholder"/>

--- a/content/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/templates/ng-ionic-page/.content.xml
+++ b/content/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/templates/ng-ionic-page/.content.xml
@@ -3,7 +3,7 @@
     jcr:description="Template for building Ionic PhoneGap pages"
     jcr:primaryType="cq:Template"
     jcr:title="Ionic PhoneGap page"
-    allowedPaths="[/content/phonegap(/.*)?]"
+    allowedPaths="[/content/phonegap/app_name_placeholder(/.*)?]"
     ranking="{Long}-3">
     <jcr:content
         cq:designPath="/etc/designs/phonegap/brand_name_placeholder/app_name_placeholder"

--- a/content/src/main/content/jcr_root/content/phonegap/app_name_placeholder/shell/.content.xml
+++ b/content/src/main/content/jcr_root/content/phonegap/app_name_placeholder/shell/.content.xml
@@ -6,7 +6,7 @@
         cq:lastModified="{Date}2014-09-04T16:49:51.266-04:00"
         cq:lastModifiedBy="admin"
         jcr:primaryType="cq:PageContent"
-        jcr:title="app_name_placeholder Shell"
+        jcr:title="app_name_placeholder App"
         sling:resourceType="brand_name_placeholder/app_name_placeholder/components/splash-page"
         pge-type="[app-instance]"
         phonegap-build-exportTemplate="/content/phonegap/app_name_placeholder/shell/jcr:content/pge-app/app_name_placeholder"

--- a/content/src/main/content/jcr_root/content/phonegap/app_name_placeholder/shell/_jcr_content/pge-app/app-config-dev/.content.xml
+++ b/content/src/main/content/jcr_root/content/phonegap/app_name_placeholder/shell/_jcr_content/pge-app/app-config-dev/.content.xml
@@ -5,7 +5,7 @@
     cq:lastReplicationAction="Activate"
     jcr:mixinTypes="[cq:ReplicationStatus]"
     jcr:primaryType="cq:ContentSyncConfig"
-    jcr:title="app_name_placeholder Shell - Dev"
+    jcr:title="app_name_placeholder App - Dev"
     sling:resourceType="contentsync/config"
     authorizable="everyone"
     updateUser="admin"/>

--- a/content/src/main/content/jcr_root/etc/designs/phonegap/brand_name_placeholder/app_name_placeholder/.content.xml
+++ b/content/src/main/content/jcr_root/etc/designs/phonegap/brand_name_placeholder/app_name_placeholder/.content.xml
@@ -14,7 +14,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="foundation/components/parsys"
-                components="[/apps/geometrixx-outdoors-app/components/image,group:PhoneGap,group:PhoneGap API]">
+                components="[group:brand_name_placeholder app_name_placeholder,group:PhoneGap,group:PhoneGap API]">
                 <section jcr:primaryType="nt:unstructured"/>
             </content-par>
         </ng-ionic-page>


### PR DESCRIPTION
Resolve https://github.com/blefebvre/aem-phonegap-starter-kit/issues/14 by changing "Shell" to "App"
Resolve https://github.com/blefebvre/aem-phonegap-starter-kit/issues/12 by setting app's component group to "Brand name" "App name"
Resolve https://github.com/blefebvre/aem-phonegap-starter-kit/issues/17 by setting allowed path for templates to just the app directory rather than all phonegap apps