### PR TITLE
fixes #48 - App built with the starter-kit 'Create App' template does not run

### DIFF
--- a/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/en/.content.xml
+++ b/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/en/.content.xml
@@ -11,7 +11,7 @@
         jcr:title="English"
         sling:resourceType="brand_name_placeholder/app_name_placeholder/components/splash-page"
         pge-type="[app-content]"
-        phonegap-exportTemplate="pge-app/app-config">
+        phonegap-exportTemplate="./pge-app/app-config">
         <pge-app jcr:primaryType="nt:unstructured">
             <app-config/>
             <app-config-dev/>

--- a/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/shell/.content.xml
+++ b/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/shell/.content.xml
@@ -29,5 +29,10 @@
                 jcr:primaryType="nt:unstructured"
                 sling:resources="[]"/>
         </screenshots>
+        <widget jcr:primaryType="nt:unstructured">
+            <content
+                jcr:primaryType="nt:unstructured"
+                src="../../../../en"/>
+        </widget>
     </jcr:content>
 </jcr:root>

--- a/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/shell/_jcr_content/pge-app/app-content/phonegap/www/config.xml
+++ b/content-core/src/main/content/jcr_root/apps/brand_name_placeholder/app_name_placeholder/app-templates/starter-kit/shell/_jcr_content/pge-app/app-content/phonegap/www/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.mobileapps" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget id="com.brand_name_placeholder" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:gap="http://phonegap.com/ns/1.0">
     <name>app_name_placeholder</name>
     <description>
         app_name_placeholder app
@@ -45,7 +45,7 @@
     <gap:plugin name="cordova-plugin-geolocation" source="npm" version="^1.0.0" />
     <gap:plugin name="cordova-plugin-network-information" source="npm" version="^1.0.0" />
     <!-- Console plugin is not relevant for Build -->
-    <gap:plugin name="cordova-plugin-zip" source="npm" version="3.0.0" />
+    <gap:plugin name="phonegap-plugin-contentsync" source="npm" version="1.1.12" />
     <gap:plugin name="cordova-plugin-dialogs" source="npm" version="^1.1.0" />
     <gap:plugin name="cordova-plugin-statusbar" source="npm" version="^1.0.0" />
     <gap:plugin name="cordova-plugin-splashscreen" source="npm" version="^1.0.0" />
@@ -61,14 +61,14 @@
     <plugin name="cordova-plugin-geolocation" spec="^1.0.0" />
     <plugin name="cordova-plugin-network-information" spec="^1.0.0" />
     <plugin name="cordova-plugin-console" spec="^1.0.0" />
-    <plugin name="cordova-plugin-zip" spec="3.0.0" />
+    <plugin name="phonegap-plugin-contentsync" spec="1.1.12" />
     <plugin name="cordova-plugin-dialogs" spec="^1.1.0" />
     <plugin name="cordova-plugin-statusbar" spec="^1.0.0" />
     <plugin name="cordova-plugin-splashscreen" spec="^1.0.0" />
     <plugin name="cordova-plugin-camera" spec="^1.1.0" />
     <plugin name="cordova-plugin-inappbrowser" spec="^1.0.0" />
     <plugin name="com.telerik.plugins.nativepagetransitions" spec="https://github.com/Telerik-Verified-Plugins/NativePageTransitions#0.4.1" />
-    <plugin name="ADBMobile" spec="https://github.com/Adobe-Marketing-Cloud/mobile-services#0482f9cedf90c98a8d4b07219ece1933b2e46a60" />
+    <plugin name="ADBMobile" spec="https://github.com/Adobe-Marketing-Cloud/mobile-services#v4.5.6-iOS" />
     <plugin name="com.phonegap.plugins.pushplugin" spec="https://github.com/phonegap-build/PushPlugin#1979d972b6ab37e28cf2077bc7ebfe706cc4dacd" />
 
     <!-- Platforms -->


### PR DESCRIPTION
- update template to provide relative start path
- update config.xml to use same plugins as main app
- fix issue with content sync path